### PR TITLE
Support `level-web-stream` in stream benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "keyspace": "^0.0.1",
     "level-read-stream": "^1.0.1",
     "level-test": "^9.0.0",
+    "level-web-stream": "^1.0.0",
     "mkdirp": "~0.5.1",
     "reachdown": "^1.0.0",
     "resolve": "^1.12.0",


### PR DESCRIPTION
Not sure how to make this fairer, in comparison to Node.js streams. I don't see a way to synchronously read out the buffered data; atm a promise is used for every item.

For https://github.com/Level/web-stream/issues/1.